### PR TITLE
Fix compilation errors on OTP 20.1+ when on top of macOS Big Sur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.1] - 2020-12-08
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- compilation errors on OTP 20.1+ when on top of macOS Big Sur
+
 ## [1.1.0] - 2020-12-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ rebar.config
 ``` erlang
 {deps,
  [% [...]
-  {tls_certificate_check, "1.1.0"}
+  {tls_certificate_check, "1.1.1"}
   ]}.
 ```
 
@@ -58,7 +58,7 @@ mix.exs
   defp deps do
     [
       # [...]
-      {:tls_certificate_check, "1.1.0"}
+      {:tls_certificate_check, "1.1.1"}
     ]
   end
 ```

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -29,7 +29,7 @@ chains</a>.
 <pre lang="erlang" class="erlang">
 {deps,
  [% [...]
-  {tls_certificate_check, "1.1.0"}
+  {tls_certificate_check, "1.1.1"}
   ]}.
 </pre>
 </details>
@@ -64,7 +64,7 @@ ssl:connect(Host, 443, Options, 5000)
   defp deps do
     [
       # [...]
-      {:tls_certificate_check, "1.1.0"}
+      {:tls_certificate_check, "1.1.1"}
     ]
   end
 </pre>

--- a/rebar.config
+++ b/rebar.config
@@ -7,8 +7,8 @@
   warn_shadow_vars,
   warn_unused_import,
   warnings_as_errors,
-  {platform_define, "^(1)|(20)", 'NO_CUSTOM_HOSTNAME_CHECK'},
-  {platform_define, "^(1)|(20)", 'NO_URI_STRING'},
+  {platform_define, "^(1|(20))", 'NO_CUSTOM_HOSTNAME_CHECK'},
+  {platform_define, "^(1|(20))", 'NO_URI_STRING'},
   {platform_define, "^19",       'SSL_OLD_CLIENT_OPTIONS'},
   {platform_define, "^20",       'SSL_OLD_CLIENT_OPTIONS'},
   {platform_define, "^21.[0-2]", 'SSL_OLD_CLIENT_OPTIONS'}


### PR DESCRIPTION
Closes #3 .