### PR TITLE
Avoid crashing shared state owner after reading OS-trusted CAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- (rare?) crash after reading OS-trusted CAs
+
 ## [1.17.2] - 2023-01-12
 
 ### Fixed

--- a/src/tls_certificate_check_shared_state.erl
+++ b/src/tls_certificate_check_shared_state.erl
@@ -62,7 +62,6 @@
 -export([init/1,
          handle_call/3,
          handle_cast/2,
-         handle_info/2,
          terminate/2,
          code_change/3]).
 
@@ -223,11 +222,6 @@ handle_cast({initialize_shared_state, EncodedHardcodedAuthorities}, State)
     handle_shared_state_initialization(EncodedHardcodedAuthorities, State);
 handle_cast(Request, State) ->
     {stop, {unexpected_cast, Request}, State}.
-
--spec handle_info(term(), state())
-        -> {stop, {unexpected_info, term()}, state()}.
-handle_info(Info, State) ->
-    {stop, {unexpected_info, Info}, State}.
 
 -spec terminate(term(), state()) -> ok.
 terminate(Reason, _State) ->


### PR DESCRIPTION
Specifically, when the file port exits before the OTP code we've invoked unlinks from it, thus triggering an `EXIT` message (or so I speculate).

Closes #35 