### PR TITLE
Fix error starting app when OS-trusted CAs fail to load on OTP 25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - error starting application when OS-trusted CAs fail to load on OTP 25
+[present since 1.17.0]
 
 ## [1.17.3] - 2023-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- error starting application when OS-trusted CAs fail to load on OTP 25
+
 ## [1.17.3] - 2023-01-17
 
 ### Fixed

--- a/rebar.config
+++ b/rebar.config
@@ -69,7 +69,10 @@
             nowarn_missing_spec,
             nowarnings_as_errors
         ]},
-        {deps, [{certifi, "2.10.0"}]},
+        {deps, [
+            {certifi, "2.10.0"},
+            {meck, "0.9.2"}
+        ]},
         {cover_enabled, true},
         {cover_opts, [verbose]}
     ]},

--- a/src/tls_certificate_check_shared_state.erl
+++ b/src/tls_certificate_check_shared_state.erl
@@ -534,6 +534,7 @@ compare_certificate_timestamps_([], []) ->
 -ifndef(NO_PUBLIC_KEY_CACERTS_GET).
 
 missing_otp_provided_CAs_falls_back_gracefully_test() ->
+    _ = application:stop(tls_certificate_check),
     {ok, _} = application:ensure_all_started(meck),
     {ok, _} = application:ensure_all_started(public_key),
 

--- a/src/tls_certificate_check_shared_state.erl
+++ b/src/tls_certificate_check_shared_state.erl
@@ -373,7 +373,7 @@ maybe_load_authorities_trusted_by_otp(true = _UseOtpTrustedCAs,
                                             <- CombinedAuthoritativeCertificateValues],
             {ok, AuthoritativeCertificateValues, _Source = otp}
     catch
-        Class:Reason when Class =/= error, Reason =/= undef ->
+        Class:Reason when Class =/= error; Reason =/= undef ->
             ?LOG_WARNING("Failed to load OTP-trusted CAs: ~p:~p"
                          ", falling back to hardcoded authorities", [Class, Reason]),
             process_authorities(UnprocessedAuthorities, UnprocessedAuthoritiesSource)

--- a/src/tls_certificate_check_shared_state.erl
+++ b/src/tls_certificate_check_shared_state.erl
@@ -27,6 +27,10 @@
 -include_lib("public_key/include/public_key.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
 %% ------------------------------------------------------------------
 %% API Function Exports
 %% ------------------------------------------------------------------
@@ -522,3 +526,24 @@ compare_certificate_timestamps_([X|A], [Y|B]) ->
     end;
 compare_certificate_timestamps_([], []) ->
     equal.
+
+%% ------------------------------------------------------------------
+%% Unit Test Definitions
+%% ------------------------------------------------------------------
+-ifdef(TEST).
+-ifndef(NO_PUBLIC_KEY_CACERTS_GET).
+
+missing_otp_provided_CAs_falls_back_gracefully_test() ->
+    {ok, _} = application:ensure_all_started(meck),
+    {ok, _} = application:ensure_all_started(public_key),
+
+    ok = meck:new(public_key, [passthrough]),
+    ok = meck:expect(public_key, cacerts_get, fun () -> error({badmatch, foobar}) end),
+    try
+        {ok, _} = application:ensure_all_started(tls_certificate_check)
+    after
+        ok = meck:unload(public_key)
+    end.
+
+-endif.
+-endif.


### PR DESCRIPTION
Fixes #37 , present since 1.17.0